### PR TITLE
Update preset ID after loading list

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -638,6 +638,11 @@ window.addEventListener("DOMContentLoaded", async () => {
         else if (id === 0xF8) { // LIST_END
           clearTimeout(timeout);
           window.removeEventListener('esp32-ack', handlePresetListAck);
+
+          // Determine the next available preset ID
+          const ids = Array.from(esp32Presets.keys());
+          nextPresetId = ids.length > 0 ? Math.max(...ids) + 1 : 1;
+
           resolve();
         }
       };


### PR DESCRIPTION
## Summary
- update `loadESP32PresetList` to calculate `nextPresetId` after the preset list is loaded
- keep incrementing `nextPresetId` only after a successful save

## Testing
- `npm run build-web`


------
https://chatgpt.com/codex/tasks/task_e_686cefd59170832393b813ccc25a5326