### PR TITLE
Add preset naming support

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -471,7 +471,7 @@ window.addEventListener("DOMContentLoaded", async () => {
         
         if (id === 0xF9 && value === presetId) {
           // ESP32 ready to receive field data
-          sendAllFieldsToESP32(presetData);
+          sendAllFieldsToESP32(presetData, presetName);
           return;
         }
         
@@ -493,7 +493,7 @@ window.addEventListener("DOMContentLoaded", async () => {
         }
       };
 
-      const sendAllFieldsToESP32 = (data) => {
+      const sendAllFieldsToESP32 = (data, name) => {
         const fieldMap = {
           feedRate: 0x20,
           loopHeightInput: 0x21,
@@ -508,14 +508,25 @@ window.addEventListener("DOMContentLoaded", async () => {
           servoPwmMin: 0x2A,
           servoPwmMax: 0x2B
         };
-        
-        fieldsToSend = Object.keys(fieldMap).length;
-        
+        const nameChunks = 8;
+        fieldsToSend = Object.keys(fieldMap).length + nameChunks;
+
         // Send each field
         Object.entries(fieldMap).forEach(([fieldName, fieldId]) => {
           const value = data[fieldName] || 0;
           sendFrame(CMD_SAVE_PRESET_FIELD, fieldId, value);
         });
+
+        const enc = new TextEncoder();
+        const bytes = new Uint8Array(32);
+        bytes.fill(0);
+        const encBytes = enc.encode(name);
+        bytes.set(encBytes.slice(0, 32));
+        for (let i = 0; i < nameChunks; i++) {
+          const dv = new DataView(bytes.buffer, i * 4, 4);
+          const floatVal = dv.getFloat32(0, true);
+          sendFrame(CMD_SAVE_PRESET_FIELD, 0x30 + i, floatVal);
+        }
       };
 
       window.addEventListener('esp32-ack', handleSaveAck);
@@ -613,6 +624,9 @@ window.addEventListener("DOMContentLoaded", async () => {
         reject(new Error("Timeout waiting for ESP32 preset list"));
       }, 5000);
 
+      let pendingId = null;
+      let nameBytes = [];
+
       const handlePresetListAck = (event) => {
         const { id, value } = event.detail;
         
@@ -621,18 +635,30 @@ window.addEventListener("DOMContentLoaded", async () => {
           return;
         }
         else if (id === 0xF5) { // PRESET_EXISTS
-          const presetId = value;
-          const presetName = `ESP32 Preset ${presetId}`;
-          esp32Presets.set(presetId, presetName);
-          
-          // Add to dropdown if not already there
-          const existingOption = dd.querySelector(`option[data-preset-id="${presetId}"]`);
-          if (!existingOption) {
-            const opt = document.createElement("option");
-            opt.value = opt.textContent = presetName;
-            opt.dataset.presetId = presetId;
-            opt.dataset.source = "esp32";
-            dd.appendChild(opt);
+          pendingId = value;
+          nameBytes = [];
+        }
+        else if (id === 0xF6 && pendingId !== null) {
+          const dv = new DataView(new ArrayBuffer(4));
+          dv.setFloat32(0, value, true);
+          for (let i = 0; i < 4; i++) nameBytes.push(dv.getUint8(i));
+          if (nameBytes.length >= 32) {
+            const dec = new TextDecoder();
+            const name = dec.decode(new Uint8Array(nameBytes)).replace(/\0.*$/, '') || `ESP32 Preset ${pendingId}`;
+            esp32Presets.set(pendingId, name);
+            const existingOption = dd.querySelector(`option[data-preset-id="${pendingId}"]`);
+            if (!existingOption) {
+              const opt = document.createElement("option");
+              opt.value = opt.textContent = name;
+              opt.dataset.presetId = pendingId;
+              opt.dataset.source = "esp32";
+              dd.appendChild(opt);
+            } else {
+              existingOption.textContent = name;
+              existingOption.value = name;
+            }
+            pendingId = null;
+            nameBytes = [];
           }
         }
         else if (id === 0xF8) { // LIST_END

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,8 @@ struct Preset {
   // Checkboxes
   uint8_t runYoke;
   uint8_t runConveyor;
+
+  char name[32];
 };
 #pragma pack()
 
@@ -316,11 +318,18 @@ void processIncomingFrame(uint8_t *buf, size_t len)
     Serial.printf("[DEBUG] Sending preset count: %d\n", count);
     sendFrame(CMD_ACK, 0xF3, count);
     
-    // Send each existing preset ID
+    // Send each existing preset ID and name
     for (uint8_t i = 1; i <= 100; i++) {
       if (prefs.isKey(String(i).c_str())) {
-        Serial.printf("[DEBUG] Found preset ID: %d\n", i);
+        Preset preset = {};
+        prefs.getBytes(String(i).c_str(), &preset, sizeof(Preset));
+        Serial.printf("[DEBUG] Found preset ID: %d name: %s\n", i, preset.name);
         sendFrame(CMD_ACK, 0xF5, i);  // 0xF5 = PRESET_EXISTS
+        for (uint8_t c = 0; c < 8; c++) {
+          FloatBytes fbName;
+          memcpy(fbName.b, &preset.name[c*4], 4);
+          sendFrame(CMD_ACK, 0xF6, fbName.f);  // send name chunk
+        }
       }
     }
     
@@ -343,6 +352,7 @@ void processIncomingFrame(uint8_t *buf, size_t len)
     // Store the preset ID for the upcoming data
     currentPresetId = presetId;
     currentPresetData = {}; // Reset struct
+    memset(currentPresetData.name, 0, sizeof(currentPresetData.name));
     
     // Copy current MCU values
     currentPresetData.riseTime = riseTime;
@@ -378,6 +388,14 @@ void processIncomingFrame(uint8_t *buf, size_t len)
       case 0x29: currentPresetData.minAngleRaw = value; break;
       case 0x2A: currentPresetData.servoPwmMinUser = value; break;
       case 0x2B: currentPresetData.servoPwmMaxUser = value; break;
+      case 0x30: memcpy(&currentPresetData.name[0], fb.b, 4); break;
+      case 0x31: memcpy(&currentPresetData.name[4], fb.b, 4); break;
+      case 0x32: memcpy(&currentPresetData.name[8], fb.b, 4); break;
+      case 0x33: memcpy(&currentPresetData.name[12], fb.b, 4); break;
+      case 0x34: memcpy(&currentPresetData.name[16], fb.b, 4); break;
+      case 0x35: memcpy(&currentPresetData.name[20], fb.b, 4); break;
+      case 0x36: memcpy(&currentPresetData.name[24], fb.b, 4); break;
+      case 0x37: memcpy(&currentPresetData.name[28], fb.b, 4); break;
     }
     
     sendFrame(CMD_ACK, 0xFA, fieldId); // Field received
@@ -592,6 +610,8 @@ void savePresetToNVS(uint8_t presetId) {
     .servoPwmMin = (float)servoPwmMin,
     .servoPwmMax = (float)servoPwmMax
   };
+
+  snprintf(preset.name, sizeof(preset.name), "Preset %u", presetId);
   
   // Save binary preset data directly using preset ID as key
   prefs.putBytes(String(presetId).c_str(), &preset, sizeof(Preset));
@@ -628,12 +648,12 @@ void loadPresetFromNVS(uint8_t presetId) {
   prefs.begin("presets", true);
   size_t dataSize = prefs.getBytesLength(String(presetId).c_str());
   
-  if (dataSize == sizeof(Preset)) {
-    Preset preset;
-    size_t bytesRead = prefs.getBytes(String(presetId).c_str(), &preset, sizeof(Preset));
+  if (dataSize == sizeof(Preset) || dataSize == 86) {
+    Preset preset = {};
+    size_t bytesRead = prefs.getBytes(String(presetId).c_str(), &preset, min(dataSize, sizeof(Preset)));
     prefs.end();
-    
-    if (bytesRead == sizeof(Preset)) {
+
+    if (bytesRead == dataSize) {
       // Apply MCU values
       riseTime = constrain(preset.riseTime, 1.0f, 10000.0f);
       fallTime = constrain(preset.fallTime, 1.0f, 10000.0f);
@@ -776,11 +796,14 @@ void loop()
 
 void savePresetToNVSWithData(uint8_t presetId, const Preset& presetData) {
   if (presetId == 0 || presetId > 100) return;
-  
+
   prefs.begin("presets", false);
-  
+
   // Save the complete preset data
-  prefs.putBytes(String(presetId).c_str(), &presetData, sizeof(Preset));
+  Preset tmp = presetData;
+  if (tmp.name[0] == '\0')
+    snprintf(tmp.name, sizeof(tmp.name), "Preset %u", presetId);
+  prefs.putBytes(String(presetId).c_str(), &tmp, sizeof(Preset));
   Serial.printf("[DEBUG] Saved full preset ID %d, size: %d bytes\n", presetId, sizeof(Preset));
   
   // Update preset count


### PR DESCRIPTION
## Summary
- extend `Preset` struct with `name[32]`
- store and load preset names in NVS
- send preset names when listing presets
- allow saving preset names from browser
- parse names in `loadESP32PresetList`
- compile web assets

## Testing
- `npm run build-web`

------
https://chatgpt.com/codex/tasks/task_e_686cefd6b25483239cac94d5800b856b