### PR TITLE
Simplify NVS init in setup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,9 +745,7 @@ void setup()
 {
   Serial.begin(115200);
 
-  prefs.begin("params", /*rw=*/false);   // open read-only first
-  loadFromNVS();                         // <— new helper (below)
-  prefs.end();
+  loadFromNVS();
 
   myServo.attach(PWM_PIN, servoPwmMin, servoPwmMax);
   currAngle = minAngle;  // Initialize current angle


### PR DESCRIPTION
## Summary
- remove redundant Preferences begin/end calls in `setup()`
- rely on `loadFromNVS()` to manage Preferences access

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d04a5f2708323bb82528e736b1be1